### PR TITLE
Don't reference uninitialized variables

### DIFF
--- a/base_util.c
+++ b/base_util.c
@@ -45,6 +45,7 @@ void copy_array(struct Value * a, struct Value_array * b){
 struct Tree * duplicate_tree(struct Tree * a){
     struct Tree * root = malloc(sizeof(struct Tree));
     root->type = a->type;
+    root->size = 0;
     copy_value(&root->content, &a->content);
     for(int i = 0; i < a->size; i++){
         root->children[i] = duplicate_tree(a->children[i]);

--- a/execute.c
+++ b/execute.c
@@ -20,35 +20,35 @@
 struct Value execute (struct Tree * ast, struct Tree_map * defined, struct Map * let_map){
     struct Value result;
     // first check for special kinds of execution
-    if(string_matches(ast->content.data.str, if_const)){
+    if(ast->type == 'k' && string_matches(ast->content.data.str, if_const)){
         return if_block(ast, defined, let_map);
     }
-    else if(string_matches(let_const, ast->content.data.str)){
+    else if(ast->type == 'k' && string_matches(let_const, ast->content.data.str)){
         store_let_binding(ast, defined, let_map);
         result.type = 'u';
     }
-    else if(string_matches(each_const, ast->content.data.str)){
+    else if(ast->type == 'k' && string_matches(each_const, ast->content.data.str)){
         for_each(ast, defined, let_map);
         result.type = 'u';
     }
-    else if(string_matches(map_const, ast->content.data.str)){
+    else if(ast->type == 'k' && string_matches(map_const, ast->content.data.str)){
         return map_array(ast, defined, let_map);
     }
-    else if(string_matches(reduce_const, ast->content.data.str)){
+    else if(ast->type == 'k' && string_matches(reduce_const, ast->content.data.str)){
         return reduce_array(ast, defined, let_map);
     }
-    else if(string_matches(set_const, ast->content.data.str)){
+    else if(ast->type == 'k' && string_matches(set_const, ast->content.data.str)){
         struct Value index = execute(ast->children[0], defined, let_map);
         struct Value item = execute(ast->children[1], defined, let_map);
         struct Value array = execute(ast->children[2], defined, let_map);
         result = array_set(index, item, array);
         return result;
     }
-    else if(string_matches(for_const, ast->content.data.str)){
+    else if(ast->type == 'k' && string_matches(for_const, ast->content.data.str)){
         for_loop(ast, defined, let_map);
         result.type = 'u'; //return undefined
     }
-    else if(string_matches(do_const, ast->content.data.str)){
+    else if(ast->type == 'k' && string_matches(do_const, ast->content.data.str)){
         for(int i = 0; i < ast->size; i++){
             if(i == ast->size-1){
                 result = execute(ast->children[i], defined, let_map);
@@ -57,10 +57,10 @@ struct Value execute (struct Tree * ast, struct Tree_map * defined, struct Map *
             }
         }
     }
-    else if(string_matches(read_const, ast->content.data.str)){
+    else if(ast->type == 'k' && string_matches(read_const, ast->content.data.str)){
         return read_file(ast->children[0]->content.data.str);
     }
-    else if(string_matches(substring_const, ast->content.data.str)){
+    else if(ast->type == 'k' && string_matches(substring_const, ast->content.data.str)){
         struct Value string = execute(ast->children[2], defined, let_map);
         struct Value start = execute(ast->children[0], defined, let_map);
         struct Value end = execute(ast->children[1], defined, let_map);
@@ -72,7 +72,7 @@ struct Value execute (struct Tree * ast, struct Tree_map * defined, struct Map *
             return substring(start.data.ln, end.data.ln, string);
         }
     }
-    else if(string_matches(parallel_const, ast->content.data.str)){
+    else if(ast->type == 'k' && string_matches(parallel_const, ast->content.data.str)){
         parallel_execution(ast, defined, let_map);
         result.type = 'u';
     } else {

--- a/huo.c
+++ b/huo.c
@@ -52,7 +52,9 @@ int main(int argc, char const *argv[]) {
     // printTree(&root);
     // printf("\n");
     struct Tree_map * defined = malloc(sizeof(struct Tree_map));
+    defined->size = 0;
     struct Map * let_map = malloc(sizeof(struct Map));
+    let_map->size = 0;
     int num_defs = store_defs(&root, defined);
     for(int i = num_defs; i < root.size; i++){
         execute(root.children[i], defined, let_map);

--- a/process_defs.c
+++ b/process_defs.c
@@ -6,6 +6,7 @@
 
 struct Map * make_args_map(struct Tree * ast, struct Tree_map * defined, int idx){
     struct Map * arguments = malloc(sizeof(struct Map));
+    arguments->size = 0;
     for(int i = 0; i < ast->size; i++){
         struct Keyval * store = malloc(sizeof(struct Keyval));
         struct Value * key = malloc(sizeof(struct Value));


### PR DESCRIPTION
Malloc does _not_ necessarily fill memory returned with zeroes.

Also, execute tries to check if everything is a keyword, even if it's an AST node that doesn't contain a string.
