### PR TITLE
factor out special execution functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ objs = \
   src/execution_functions/while_loop.o\
   src/execution_functions/evaluate.o\
   src/execution_functions/read_line.o\
+  src/apply_execution_function.o\
   src/build_array.o \
   src/tokenizer.o \
   src/process_defs.o \

--- a/examples/for_do.txt
+++ b/examples/for_do.txt
@@ -3,10 +3,9 @@
     (let x (+ x x))
 )
 (print x)
-(let y [ 1 ])
+(let y [ ])
 (for 0 25
     (do
-        (print (length y))
         (set (length y) (length y) y)
     )
 )

--- a/examples/imports.txt
+++ b/examples/imports.txt
@@ -1,3 +1,3 @@
 (import "examples/library.txt")
 (print (factorial 20))
-(print (avg [1,2,3,4,5,6,7,8]))
+(print (avg [1,2,3,4,5,6,7,-8, 123, 45, 2, 67, -1657, 4, -6.6, 9]))

--- a/src/apply_core_function.c
+++ b/src/apply_core_function.c
@@ -11,7 +11,7 @@ struct Value apply_core_function(struct Tree * ast, struct Value a, struct Value
             return concat(a, b);
         }
         else if(string_matches_heap(&index_const, kwd)){
-            return array_index(a, b);
+            return value_index(a, b);
         }
         else if(string_matches_heap(&push_const, kwd)){
             return push(a, b);

--- a/src/apply_core_function.c
+++ b/src/apply_core_function.c
@@ -11,7 +11,7 @@ struct Value apply_core_function(struct Tree * ast, struct Value a, struct Value
             return concat(a, b);
         }
         else if(string_matches_heap(&index_const, kwd)){
-            return index(a, b);
+            return array_index(a, b);
         }
         else if(string_matches_heap(&push_const, kwd)){
             return push(a, b);

--- a/src/apply_execution_function.c
+++ b/src/apply_execution_function.c
@@ -22,51 +22,48 @@ struct Value apply_execution_function(struct Tree * ast, hash_table * defined, s
     struct Value undefined = {
         .type = UNDEF
     };
-    if(string_matches_heap(&ast->content.data.str, &if_const)){
+    if(ast->content.type == KEYWORD && string_matches_heap(&ast->content.data.str, &if_const)){
         return if_block(ast, defined, scopes, function_names, max_depth-1);
     }
-    else if(string_matches_heap(&let_const, &ast->content.data.str)){
+    else if(ast->content.type == KEYWORD && string_matches_heap(&let_const, &ast->content.data.str)){
         if (ast->size < 2) {
             ERROR("Not enough arguments for store_let_binding: %i < 2\n", ast->size);
         }
         store_let_binding(ast->children[0],ast->children[1], defined, scopes, function_names, max_depth-1);
         return undefined;
     }
-    else if(string_matches_heap(&each_const, &ast->content.data.str)){
+    else if(ast->content.type == KEYWORD && string_matches_heap(&each_const, &ast->content.data.str)){
         for_each(ast, defined, scopes, function_names, max_depth-1);
         return undefined;
     }
-    else if(string_matches_heap(&map_const, &ast->content.data.str)){
+    else if(ast->content.type == KEYWORD && string_matches_heap(&map_const, &ast->content.data.str)){
         return map_array(ast, defined, scopes, function_names, max_depth-1);
     }
-    else if(string_matches_heap(&while_const, &ast->content.data.str)){
+    else if(ast->content.type == KEYWORD && string_matches_heap(&while_const, &ast->content.data.str)){
         while_loop(ast, defined, scopes, function_names, max_depth - 1);
         return undefined;
     }
-    else if(string_matches_heap(&reduce_const, &ast->content.data.str)){
+    else if(ast->content.type == KEYWORD && string_matches_heap(&reduce_const, &ast->content.data.str)){
         return reduce_array(ast, defined, scopes, function_names, max_depth - 1);
     }
-    else if(string_matches_heap(&set_const, &ast->content.data.str)) {
+    else if(ast->content.type == KEYWORD && string_matches_heap(&set_const, &ast->content.data.str)) {
         if (ast->size < 3) {
             ERROR("Not enough arguments for set: %i < 3", ast->size);
         }
         struct Value index = execute(ast->children[0], defined, scopes, function_names, max_depth-1);
         struct Value item = execute(ast->children[1], defined, scopes, function_names, max_depth-1);
         struct Value array = execute(ast->children[2], defined, scopes, function_names, max_depth-1);
-        if(array.type == STRING){
-            return set(index, item, array);
-        }
-        else if(array.type == ARRAY){
-            return set(index, item, array);
-        } else {
-            ERROR("Error using set with wrong type ('%c' !== ['a'|'s'])", array.type);
-        }
+
+        return set(index, item, array);
     }
-    else if(string_matches_heap(&for_const, &ast->content.data.str)){
+    else if(ast->content.type == KEYWORD && string_matches_heap(&for_const, &ast->content.data.str)){
         for_loop(ast, defined, scopes, function_names, max_depth - 1);
         return undefined;
     }
-    else if(string_matches_heap(&do_const, &ast->content.data.str)){
+    else if(ast->content.type == KEYWORD && string_matches_heap(&do_const, &ast->content.data.str)){
+        if (!ast->size) {
+            ERROR("Not enough arguments for do: %i < 1", ast->size);
+        }
         for(int i = 0; i < ast->size; i++){
             if(i == ast->size-1){
                 return execute(ast->children[i], defined, scopes, function_names, max_depth-1);
@@ -75,7 +72,7 @@ struct Value apply_execution_function(struct Tree * ast, hash_table * defined, s
             }
         }
     }
-    else if(string_matches_heap(&read_const, &ast->content.data.str)){
+    else if(ast->content.type == KEYWORD && string_matches_heap(&read_const, &ast->content.data.str)){
         if (ast->size < 1) {
             ERROR("Not enough arguments for read: %i < 1", ast->size);
         }
@@ -85,24 +82,20 @@ struct Value apply_execution_function(struct Tree * ast, hash_table * defined, s
         }
         return value_from_string(read_file(ast->children[0]->content.data.str));
     }
-    else if(string_matches_heap(&substring_const, &ast->content.data.str)){
+    else if(ast->content.type == KEYWORD && string_matches_heap(&substring_const, &ast->content.data.str)){
         if (ast->size < 3) {
             ERROR("Not enough arguments for substring: %i < 3", ast->size);
         }
         struct Value string = execute(ast->children[2], defined, scopes, function_names, max_depth-1);
         struct Value start = execute(ast->children[0], defined, scopes, function_names, max_depth-1);
         struct Value end = execute(ast->children[1], defined, scopes, function_names, max_depth-1);
-        if(string.type != STRING){
-            ERROR("Non-string value passed into substring: %c.", string.type);
-            return undefined;
-        } else {
-            return substring(start, end, string);
-        }
+        
+        return substring(start, end, string);
     }
-    else if(string_matches_heap(&switch_const, &ast->content.data.str)){
+    else if(ast->content.type == KEYWORD && string_matches_heap(&switch_const, &ast->content.data.str)){
         return switch_case(ast, defined, scopes, function_names, max_depth-1);
     }
-    else if(string_matches_heap(&parallel_const, &ast->content.data.str)){
+    else if(ast->content.type == KEYWORD && string_matches_heap(&parallel_const, &ast->content.data.str)){
         parallel_execution(ast, defined, scopes, function_names, max_depth-1);
         return undefined;
     }

--- a/src/apply_execution_function.c
+++ b/src/apply_execution_function.c
@@ -1,0 +1,110 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "structures/structures.h"
+#include "core_functions.h"
+#include "base_util.h"
+#include "process_defs.h"
+#include "constants.h"
+#include "execute.h"
+#include "execution_functions/for_each.h"
+#include "execution_functions/for_loop.h"
+#include "execution_functions/reduce.h"
+#include "execution_functions/read_file.h"
+#include "execution_functions/map_array.h"
+#include "execution_functions/if_block.h"
+#include "execution_functions/let_binding.h"
+#include "execution_functions/switch.h"
+#include "execution_functions/parallel_execution.h"
+#include "execution_functions/while_loop.h"
+
+
+struct Value apply_execution_function(struct Tree * ast, hash_table * defined, struct Scopes * scopes, struct Value_array * function_names, int max_depth){
+    struct Value undefined = {
+        .type = UNDEF
+    };
+    if(string_matches_heap(&ast->content.data.str, &if_const)){
+        return if_block(ast, defined, scopes, function_names, max_depth-1);
+    }
+    else if(string_matches_heap(&let_const, &ast->content.data.str)){
+        if (ast->size < 2) {
+            ERROR("Not enough arguments for store_let_binding: %i < 2\n", ast->size);
+        }
+        store_let_binding(ast->children[0],ast->children[1], defined, scopes, function_names, max_depth-1);
+        return undefined;
+    }
+    else if(string_matches_heap(&each_const, &ast->content.data.str)){
+        for_each(ast, defined, scopes, function_names, max_depth-1);
+        return undefined;
+    }
+    else if(string_matches_heap(&map_const, &ast->content.data.str)){
+        return map_array(ast, defined, scopes, function_names, max_depth-1);
+    }
+    else if(string_matches_heap(&while_const, &ast->content.data.str)){
+        while_loop(ast, defined, scopes, function_names, max_depth - 1);
+        return undefined;
+    }
+    else if(string_matches_heap(&reduce_const, &ast->content.data.str)){
+        return reduce_array(ast, defined, scopes, function_names, max_depth - 1);
+    }
+    else if(string_matches_heap(&set_const, &ast->content.data.str)) {
+        if (ast->size < 3) {
+            ERROR("Not enough arguments for set: %i < 3", ast->size);
+        }
+        struct Value index = execute(ast->children[0], defined, scopes, function_names, max_depth-1);
+        struct Value item = execute(ast->children[1], defined, scopes, function_names, max_depth-1);
+        struct Value array = execute(ast->children[2], defined, scopes, function_names, max_depth-1);
+        if(array.type == STRING){
+            return set(index, item, array);
+        }
+        else if(array.type == ARRAY){
+            return set(index, item, array);
+        } else {
+            ERROR("Error using set with wrong type ('%c' !== ['a'|'s'])", array.type);
+        }
+    }
+    else if(string_matches_heap(&for_const, &ast->content.data.str)){
+        for_loop(ast, defined, scopes, function_names, max_depth - 1);
+        return undefined;
+    }
+    else if(string_matches_heap(&do_const, &ast->content.data.str)){
+        for(int i = 0; i < ast->size; i++){
+            if(i == ast->size-1){
+                return execute(ast->children[i], defined, scopes, function_names, max_depth-1);
+            } else {
+                execute(ast->children[i], defined, scopes, function_names, max_depth-1);
+            }
+        }
+    }
+    else if(string_matches_heap(&read_const, &ast->content.data.str)){
+        if (ast->size < 1) {
+            ERROR("Not enough arguments for read: %i < 1", ast->size);
+        }
+        char t = ast->children[0]->content.type;
+        if (t != STRING && t != KEYWORD) {
+            ERROR("Invalid type for read: '%c' != [STRING, KEYWORD]", t);
+        }
+        return value_from_string(read_file(ast->children[0]->content.data.str));
+    }
+    else if(string_matches_heap(&substring_const, &ast->content.data.str)){
+        if (ast->size < 3) {
+            ERROR("Not enough arguments for substring: %i < 3", ast->size);
+        }
+        struct Value string = execute(ast->children[2], defined, scopes, function_names, max_depth-1);
+        struct Value start = execute(ast->children[0], defined, scopes, function_names, max_depth-1);
+        struct Value end = execute(ast->children[1], defined, scopes, function_names, max_depth-1);
+        if(string.type != STRING){
+            ERROR("Non-string value passed into substring: %c.", string.type);
+            return undefined;
+        } else {
+            return substring(start, end, string);
+        }
+    }
+    else if(string_matches_heap(&switch_const, &ast->content.data.str)){
+        return switch_case(ast, defined, scopes, function_names, max_depth-1);
+    }
+    else if(string_matches_heap(&parallel_const, &ast->content.data.str)){
+        parallel_execution(ast, defined, scopes, function_names, max_depth-1);
+        return undefined;
+    }
+    return undefined;
+}

--- a/src/apply_execution_function.h
+++ b/src/apply_execution_function.h
@@ -1,0 +1,8 @@
+#ifndef _APPLY_EXECUTION_FUNCTION_H
+#define _APPLY_EXECUTION_FUNCTION_H
+
+#include "structures/structures.h"
+
+struct Value apply_execution_function(struct Tree * ast, hash_table * defined, struct Scopes * scopes, struct Value_array * function_names, int max_depth);
+
+#endif

--- a/src/base_util.h
+++ b/src/base_util.h
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdbool.h>
 #include "structures/structures.h"
+#include <execinfo.h>
 #include "config.h"
 
 #define WARN_ONCE(...) _WARN_ONCE(warn_once_##__COUNTER__, __VA_ARGS__)
@@ -20,6 +21,13 @@
 /* Macro because it makes printf errors easier to detect at compile time */
 #define ERROR(...) ERROR_AT(__FILE__, __func__, __LINE__, __VA_ARGS__)
 #define ERROR_AT(FILE, FUNC, LINE, ...) do {\
+    void * buffer[5];\
+    char ** strings;\
+    backtrace(buffer, 5);\
+    strings = backtrace_symbols(buffer, 5);\
+    for (int i = 0; i < 5; i++){\
+        printf ("%s\n", strings[i]);\
+    }\
     fprintf(stderr, "Error at %s:%s:%i: ", FILE, FUNC, LINE);\
     fprintf(stderr, __VA_ARGS__);\
     fprintf(stderr, "\n");\

--- a/src/constants.c
+++ b/src/constants.c
@@ -7,7 +7,7 @@ const int LOOP_MAX = -1;
 
 struct String functions = STR_NEW("*+-/!=<>");
 
-struct String numbers = STR_NEW("0123456789");
+struct String numbers = STR_NEW("-0123456789");
 
 struct String letters = STR_NEW("_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ");
 

--- a/src/constants.c
+++ b/src/constants.c
@@ -61,6 +61,8 @@ struct String eval_const = STR_NEW("eval");
 
 struct String read_line_const = STR_NEW("readline");
 
+struct String function_names = STR_NEW("[if, read, let, set, each, for, do, switch, parallel, import, map, reduce, substring, while]");
+
 const char open_parens_const = '(';
 const char close_parens_const = ')';
 const char root_type_const = 'r';

--- a/src/constants.h
+++ b/src/constants.h
@@ -36,6 +36,7 @@ extern struct String default_const;
 extern struct String while_const;
 extern struct String eval_const;
 extern struct String read_line_const;
+extern struct String function_names;
 
 extern const char open_parens_const;
 extern const char close_parens_const;

--- a/src/core_functions.c
+++ b/src/core_functions.c
@@ -375,7 +375,7 @@ struct Value string_split(struct String sep, struct String what) {
 }
 
 
-struct Value array_index(struct Value index, struct Value list) {
+struct Value value_index(struct Value index, struct Value list) {
     long i = value_as_long(&index);
     if(list.type == ARRAY){
         struct Value_array *a = value_as_array(&list);

--- a/src/core_functions.c
+++ b/src/core_functions.c
@@ -375,7 +375,7 @@ struct Value string_split(struct String sep, struct String what) {
 }
 
 
-struct Value index(struct Value index, struct Value list) {
+struct Value array_index(struct Value index, struct Value list) {
     long i = value_as_long(&index);
     if(list.type == ARRAY){
         struct Value_array *a = value_as_array(&list);

--- a/src/core_functions.h
+++ b/src/core_functions.h
@@ -42,6 +42,6 @@ struct Value string_split(struct String sep, struct String what);
 
 struct Value greater_than(struct Value a, struct Value b);
 
-struct Value index(struct Value index, struct Value v);
+struct Value array_index(struct Value index, struct Value v);
 
 #endif

--- a/src/core_functions.h
+++ b/src/core_functions.h
@@ -42,6 +42,6 @@ struct Value string_split(struct String sep, struct String what);
 
 struct Value greater_than(struct Value a, struct Value b);
 
-struct Value array_index(struct Value index, struct Value v);
+struct Value value_index(struct Value index, struct Value v);
 
 #endif

--- a/src/execute.c
+++ b/src/execute.c
@@ -29,7 +29,7 @@ struct Value execute (struct Tree *ast, hash_table *defined, struct Scopes *scop
             result = value_copy_stack(&ast->content);
             sub_vars(&result, scopes, max_depth - 1);
         }
-        else if(ast->type == 'k' && ast->content.type == KEYWORD && (func = get_defined_func(defined, ast->content.data.str)) != NULL){
+        else if(ast->content.type == KEYWORD && (func = get_defined_func(defined, ast->content.data.str)) != NULL){
             make_args_map(ast, defined, scopes, function_names, func, max_depth-1);
             result = execute(duplicate_tree(get_defined_body(func)), defined, scopes, function_names, max_depth-1);
             scopes->current--;

--- a/src/execute.c
+++ b/src/execute.c
@@ -6,101 +6,21 @@
 #include "process_defs.h"
 #include "constants.h"
 #include "execute.h"
-#include "execution_functions/for_each.h"
-#include "execution_functions/for_loop.h"
-#include "execution_functions/reduce.h"
-#include "execution_functions/read_file.h"
-#include "execution_functions/map_array.h"
-#include "execution_functions/let_binding.h"
 #include "execution_functions/reduce_ast.h"
-#include "execution_functions/if_block.h"
-#include "execution_functions/switch.h"
-#include "execution_functions/parallel_execution.h"
-#include "execution_functions/while_loop.h"
 #include "execution_functions/read_line.h"
 #include "execution_functions/evaluate.h"
 #include "apply_core_function.h"
+#include "apply_execution_function.h"
 #include "config.h"
 
-struct Value execute (struct Tree * ast, hash_table *defined, struct Scopes * scopes, int max_depth){
+struct Value execute (struct Tree *ast, hash_table *defined, struct Scopes *scopes, struct Value_array *function_names, int max_depth){
     struct Value result;
     if (max_depth <= 0) {
         ERROR("Max depth exceeded in computation");
     }
     // first check for special kinds of execution
-    if(ast->type == 'k'  && ast->content.type == KEYWORD && string_matches_heap(&ast->content.data.str, &if_const)){
-        result = if_block(ast, defined, scopes, max_depth-1);
-    }
-    else if(ast->type == 'k' && ast->content.type == KEYWORD && string_matches_heap(&let_const, &ast->content.data.str)){
-        if (ast->size != 2) {
-            ERROR("Wrong number of arguments for store_let_binding: %i != 2\n", ast->size);
-        }
-        store_let_binding(ast->children[0],ast->children[1], defined, scopes, max_depth-1);
-        result.type = UNDEF;
-    }
-    else if(ast->type == 'k' && ast->content.type == KEYWORD && string_matches_heap(&each_const, &ast->content.data.str)){
-        for_each(ast, defined, scopes, max_depth-1);
-        result.type = UNDEF;
-    }
-    else if(ast->type == 'k' && ast->content.type == KEYWORD && string_matches_heap(&map_const, &ast->content.data.str)){
-        result = map_array(ast, defined, scopes, max_depth-1);
-    }
-    else if(ast->type == 'k' && ast->content.type == KEYWORD && string_matches_heap(&while_const, &ast->content.data.str)){
-        while_loop(ast, defined, scopes, max_depth - 1);
-        result.type = UNDEF;
-    }
-    else if(ast->type == 'k' && ast->content.type == KEYWORD && string_matches_heap(&reduce_const, &ast->content.data.str)){
-        result = reduce_array(ast, defined, scopes, max_depth - 1);
-    }
-    else if(ast->type == 'k' && ast->content.type == KEYWORD && string_matches_heap(&set_const, &ast->content.data.str)) {
-        if (ast->size != 3) {
-            ERROR("Wrong number of arguments for set: %i != 3", ast->size);
-        }
-        struct Value index = execute(ast->children[0], defined, scopes, max_depth-1);
-        struct Value item = execute(ast->children[1], defined, scopes, max_depth-1);
-        struct Value array = execute(ast->children[2], defined, scopes, max_depth-1);
-        result = set(index, item, array);
-    }
-    else if(ast->type == 'k' && ast->content.type == KEYWORD && string_matches_heap(&for_const, &ast->content.data.str)){
-
-        for_loop(ast, defined, scopes, max_depth - 1);
-        result.type = UNDEF; //result = undefined
-    }
-    else if(ast->type == 'k' && ast->content.type == KEYWORD && string_matches_heap(&do_const, &ast->content.data.str)){
-        for(int i = 0; i < ast->size; i++){
-            if(i == ast->size-1){
-                result = execute(ast->children[i], defined, scopes, max_depth-1);
-            } else {
-                execute(ast->children[i], defined, scopes, max_depth-1);
-            }
-        }
-    }
-    else if(ast->type == 'k' && ast->content.type == KEYWORD && string_matches_heap(&read_const, &ast->content.data.str)){
-        if (ast->size != 1) {
-            ERROR("Wrong number of arguments for read: %i != 1", ast->size);
-        }
-        char t = ast->children[0]->content.type;
-        if (t != STRING && t != KEYWORD) {
-            ERROR("Invalid type for read: '%c' != [STRING, KEYWORD]", t);
-        }
-        result = value_from_string(read_file(ast->children[0]->content.data.str));
-    }
-    else if(ast->type == 'k' && ast->content.type == KEYWORD && string_matches_heap(&substring_const, &ast->content.data.str)){
-        if (ast->size != 3) {
-            ERROR("Wrong number of arguments for substring: %i != 3", ast->size);
-        }
-        struct Value string = execute(ast->children[2], defined, scopes, max_depth-1);
-        struct Value start = execute(ast->children[0], defined, scopes, max_depth-1);
-        struct Value end = execute(ast->children[1], defined, scopes, max_depth-1);
-
-        result = substring(start, end, string);
-    }
-    else if(ast->type == 'k' && ast->content.type == KEYWORD && string_matches_heap(&switch_const, &ast->content.data.str)){
-        result = switch_case(ast, defined, scopes, max_depth-1);
-    }
-    else if(ast->type == 'k' && ast->content.type == KEYWORD && string_matches_heap(&parallel_const, &ast->content.data.str)){
-        parallel_execution(ast, defined, scopes, max_depth-1);
-        result.type = UNDEF;
+    if(ast->content.type == KEYWORD && array_contains(&ast->content, function_names)){
+        result = apply_execution_function(ast, defined, scopes, function_names, max_depth);
     } else {
         // no special execution types found, check for more basic conditions
         struct Tree *func;
@@ -110,12 +30,12 @@ struct Value execute (struct Tree * ast, hash_table *defined, struct Scopes * sc
             sub_vars(&result, scopes, max_depth - 1);
         }
         else if(ast->type == 'k' && ast->content.type == KEYWORD && (func = get_defined_func(defined, ast->content.data.str)) != NULL){
-            make_args_map(ast, defined, scopes, func, max_depth-1);
-            result = execute(duplicate_tree(get_defined_body(func)), defined, scopes, max_depth-1);
+            make_args_map(ast, defined, scopes, function_names, func, max_depth-1);
+            result = execute(duplicate_tree(get_defined_body(func)), defined, scopes, function_names, max_depth-1);
             scopes->current--;
         }
         else if(ast->size == 1){
-            struct Value a = execute(ast->children[0], defined, scopes, max_depth - 1);
+            struct Value a = execute(ast->children[0], defined, scopes, function_names, max_depth-1);
             if(ast->type == 'k' && ast->content.type == KEYWORD){
                 if(string_matches_heap(&ast->content.data.str, &print_const)){
                     print(a);
@@ -129,7 +49,7 @@ struct Value execute (struct Tree * ast, hash_table *defined, struct Scopes * sc
                     result = a;
                 }
                 else if(string_matches_heap(&ast->content.data.str, &eval_const)){
-                    result = eval(&a, defined, scopes, max_depth - 1);
+                    result = eval(&a, defined, scopes, function_names, max_depth - 1);
                 }
                 else if(string_matches_heap(&ast->content.data.str, &read_line_const)){
                     result = value_from_string(read_line(&a));
@@ -137,11 +57,11 @@ struct Value execute (struct Tree * ast, hash_table *defined, struct Scopes * sc
             }
         }
         else if(ast->size == 2) {
-            struct Value a = execute(ast->children[0], defined, scopes, max_depth-1);
-            struct Value b = execute(ast->children[1], defined, scopes, max_depth-1);
+            struct Value a = execute(ast->children[0], defined, scopes, function_names, max_depth-1);
+            struct Value b = execute(ast->children[1], defined, scopes, function_names, max_depth-1);
             result = apply_core_function(ast, a, b);
         } else {
-            result = reduce_ast(ast, defined, scopes, max_depth-1);
+            result = reduce_ast(ast, defined, scopes, function_names, max_depth-1);
         }
     }
     return result;

--- a/src/execute.h
+++ b/src/execute.h
@@ -4,7 +4,7 @@
 #include "structures/structures.h"
 
 struct Value reduce(struct Tree * ast, hash_table *defined, struct Scopes * scopes);
-struct Value execute (struct Tree *, hash_table *, struct Scopes * scopes, int max_depth);
+struct Value execute (struct Tree *, hash_table *, struct Scopes * scopes, struct Value_array *, int max_depth);
 struct Value apply_core_function(struct Tree * ast, struct Value a, struct Value b);
 
 #endif

--- a/src/execution_functions/evaluate.c
+++ b/src/execution_functions/evaluate.c
@@ -7,7 +7,7 @@
 #include "../core_functions.h"
 #include "../config.h"
 
-struct Value eval(struct Value * string, hash_table * defined, struct Scopes * scopes, int max_depth){
+struct Value eval(struct Value * string, hash_table * defined, struct Scopes * scopes, struct Value_array * function_names, int max_depth){
     struct Value result;
     struct Tokens t = {
         .length = 0,
@@ -21,7 +21,7 @@ struct Value eval(struct Value * string, hash_table * defined, struct Scopes * s
     parse(&root, tokens, true);
     int num_defs = store_defs(&root, defined);
     for(int i = num_defs; i < root.size; i++){
-        result = execute(root.children[i], defined, scopes, max_depth - 1);
+        result = execute(root.children[i], defined, scopes, function_names, max_depth - 1);
     }
     return result;
 }

--- a/src/execution_functions/evaluate.h
+++ b/src/execution_functions/evaluate.h
@@ -3,6 +3,6 @@
 
 #include "../structures/structures.h"
 
-struct Value eval(struct Value * string, hash_table * defined, struct Scopes * scopes, int max_depth);
+struct Value eval(struct Value * string, hash_table * defined, struct Scopes * scopes, struct Value_array * function_names, int max_depth);
 
 #endif

--- a/src/execution_functions/for_each.c
+++ b/src/execution_functions/for_each.c
@@ -7,7 +7,7 @@
 #include "for_each.h"
 #include "../config.h"
 
-struct Value for_each(struct Tree * ast, hash_table * defined, struct Scopes * scopes, int max_depth){
+struct Value for_each(struct Tree * ast, hash_table * defined, struct Scopes * scopes, struct Value_array * function_names, int max_depth){
     if (max_depth <= 0) {
         ERROR("Max depth exceeded in computation");
     }
@@ -22,9 +22,9 @@ struct Value for_each(struct Tree * ast, hash_table * defined, struct Scopes * s
     } else {
         ERROR("Wrong number of arguments for for_each: %i != [3,4]\n", ast->size);
     }
-    struct Value array = execute(ast->children[0], defined, scopes, max_depth - 1);
+    struct Value array = execute(ast->children[0], defined, scopes, function_names, max_depth - 1);
     if(array.type == STRING){
-        return for_each_string(value_as_string(&array), ast, defined, scopes, max_depth);
+        return for_each_string(value_as_string(&array), ast, defined, scopes, function_names, max_depth);
     } else if (array.type == ARRAY) {
         for(int i = 0; i < array.data.array->size; i++){
             struct Value *item = value_copy_heap(array.data.array->values[i]);
@@ -34,7 +34,7 @@ struct Value for_each(struct Tree * ast, hash_table * defined, struct Scopes * s
                 struct Value index = value_from_long(i);
                 store_let_value(&ast->children[2]->content, &index, scopes);
             }
-            execute(function, defined, scopes, max_depth - 1);
+            execute(function, defined, scopes, function_names, max_depth - 1);
         }
         return array;
     } else {
@@ -42,7 +42,7 @@ struct Value for_each(struct Tree * ast, hash_table * defined, struct Scopes * s
     }
 }
 
-struct Value for_each_string(struct String string, struct Tree * ast, hash_table * defined, struct Scopes * scopes, int max_depth){
+struct Value for_each_string(struct String string, struct Tree * ast, hash_table * defined, struct Scopes * scopes, struct Value_array * function_names, int max_depth){
     bool use_index;
     int func_index;
     if (ast->size == 4) {
@@ -63,7 +63,7 @@ struct Value for_each_string(struct String string, struct Tree * ast, hash_table
             struct Value index = value_from_long(i);
             store_let_value(&ast->children[2]->content, &index, scopes);
         }
-        execute(function, defined, scopes, max_depth - 1);
+        execute(function, defined, scopes, function_names, max_depth - 1);
     }
     return value_from_string(string);
 }

--- a/src/execution_functions/for_each.h
+++ b/src/execution_functions/for_each.h
@@ -3,7 +3,7 @@
 
 #include "../structures/structures.h"
 
-struct Value for_each(struct Tree * ast, hash_table * defined, struct Scopes * scopes, int max_depth);
-struct Value for_each_string(struct String string, struct Tree * ast, hash_table *defined, struct Scopes * scopes, int max_depth);
+struct Value for_each(struct Tree * ast, hash_table * defined, struct Scopes * scopes, struct Value_array * function_names, int max_depth);
+struct Value for_each_string(struct String string, struct Tree * ast, hash_table *defined, struct Scopes * scopes, struct Value_array * function_names, int max_depth);
 
 #endif

--- a/src/execution_functions/for_loop.c
+++ b/src/execution_functions/for_loop.c
@@ -3,24 +3,24 @@
 #include "../base_util.h"
 #include "../config.h"
 
-void for_loop(struct Tree * ast, hash_table *defined, struct Scopes * scopes, int max_depth){
+void for_loop(struct Tree * ast, hash_table *defined, struct Scopes * scopes, struct Value_array * function_names, int max_depth){
     if (max_depth <= 0) {
         ERROR("Max depth exceeded in computation");
     }
     if (ast->size != 3) {
         ERROR("Wrong number of arguments for for_loop: %i != 3\n", ast->size);
     }
-    struct Value start = execute(ast->children[0], defined, scopes, max_depth - 1);
-    struct Value end = execute(ast->children[1], defined, scopes, max_depth - 1);
+    struct Value start = execute(ast->children[0], defined, scopes, function_names, max_depth - 1);
+    struct Value end = execute(ast->children[1], defined, scopes, function_names, max_depth - 1);
     long start_i = value_as_long(&start);
     long end_i = value_as_long(&end);
     if(start_i > end_i){
         for(long i = start_i; i > end_i; i--){
-            execute(ast->children[2], defined, scopes, max_depth - 1);
+            execute(ast->children[2], defined, scopes, function_names, max_depth - 1);
         }
     } else {
         for(long i = start_i; i < end_i; i++){
-            execute(ast->children[2], defined, scopes, max_depth - 1);
+            execute(ast->children[2], defined, scopes, function_names, max_depth - 1);
         }
     }
 }

--- a/src/execution_functions/for_loop.h
+++ b/src/execution_functions/for_loop.h
@@ -3,6 +3,6 @@
 
 #include "../structures/structures.h"
 
-void for_loop(struct Tree * ast, hash_table *defined, struct Scopes * scopes, int max_depth);
+void for_loop(struct Tree * ast, hash_table *defined, struct Scopes * scopes, struct Value_array * function_names, int max_depth);
 
 #endif

--- a/src/execution_functions/if_block.c
+++ b/src/execution_functions/if_block.c
@@ -3,19 +3,19 @@
 #include "../base_util.h"
 #include "../config.h"
 
-struct Value if_block(struct Tree * ast, hash_table *defined, struct Scopes * scopes, int max_depth){
+struct Value if_block(struct Tree * ast, hash_table *defined, struct Scopes * scopes, struct Value_array * function_names, int max_depth){
     if (max_depth <= 0) {
         ERROR("Max depth exceeded in computation");
     }
     if (ast->size != 2 && ast->size != 3) {
         ERROR("Wrong number of arguments for if_block: %i != [2,3]\n", ast->size);
     }
-    struct Value result = execute(ast->children[0], defined, scopes, max_depth - 1);
+    struct Value result = execute(ast->children[0], defined, scopes, function_names, max_depth - 1);
     if(value_as_bool(&result)){ // result is boolean true
-        result = execute(ast->children[1], defined, scopes, max_depth - 1);
+        result = execute(ast->children[1], defined, scopes, function_names, max_depth - 1);
     }
     else if (ast->size == 3) { // result is boolean false
-        result = execute(ast->children[2], defined, scopes, max_depth - 1);
+        result = execute(ast->children[2], defined, scopes, function_names, max_depth - 1);
     } else {
         result = value_from_undef();
     }

--- a/src/execution_functions/if_block.h
+++ b/src/execution_functions/if_block.h
@@ -3,6 +3,6 @@
 
 #include "../structures/structures.h"
 
-struct Value if_block(struct Tree * ast, hash_table *defined, struct Scopes * scopes, int max_depth);
+struct Value if_block(struct Tree * ast, hash_table *defined, struct Scopes * scopes, struct Value_array * function_names, int max_depth);
 
 #endif

--- a/src/execution_functions/let_binding.c
+++ b/src/execution_functions/let_binding.c
@@ -16,10 +16,10 @@ void store_let_value(struct Value * key, struct Value * value, struct Scopes * s
     }
 }
 
-void store_let_binding(struct Tree * key, struct Tree * value, hash_table *defined, struct Scopes * scopes, int max_depth){
+void store_let_binding(struct Tree * key, struct Tree * value, hash_table *defined, struct Scopes * scopes, struct Value_array * function_names, int max_depth){
     if (max_depth <= 0) {
         ERROR("Max depth exceeded in computation");
     }
-    struct Value val = execute(value, defined, scopes, max_depth - 1);
+    struct Value val = execute(value, defined, scopes, function_names, max_depth - 1);
     store_let_value(&key->content, &val, scopes);
 }

--- a/src/execution_functions/let_binding.h
+++ b/src/execution_functions/let_binding.h
@@ -3,7 +3,7 @@
 
 #include "../structures/structures.h"
 
-void store_let_binding(struct Tree * key, struct Tree * value, hash_table *defined, struct Scopes * scopes, int max_depth);
+void store_let_binding(struct Tree * key, struct Tree * value, hash_table *defined, struct Scopes * scopes, struct Value_array * function_names, int max_depth);
 void store_let_value(struct Value * key, struct Value * value, struct Scopes * scopes);
 
 #endif

--- a/src/execution_functions/map_array.c
+++ b/src/execution_functions/map_array.c
@@ -4,7 +4,7 @@
 #include "let_binding.h"
 #include "../config.h"
 
-struct Value map_array(struct Tree * ast, hash_table *defined, struct Scopes * scopes, int max_depth){
+struct Value map_array(struct Tree * ast, hash_table *defined, struct Scopes * scopes, struct Value_array * function_names, int max_depth){
     if (max_depth <= 0) {
         ERROR("Max depth exceeded in computation");
     }
@@ -19,7 +19,7 @@ struct Value map_array(struct Tree * ast, hash_table *defined, struct Scopes * s
     } else {
         ERROR("Wrong number of arguments for map__array: %i != [3,4]\n", ast->size);
     }
-    struct Value array = execute(ast->children[0], defined, scopes, max_depth - 1);
+    struct Value array = execute(ast->children[0], defined, scopes, function_names, max_depth - 1);
     if (array.type != ARRAY) {
         ERROR("Wrong type for map: '%c' != ARRAY", array.type);
     }
@@ -31,7 +31,7 @@ struct Value map_array(struct Tree * ast, hash_table *defined, struct Scopes * s
             struct Value index = value_from_long(i);
             store_let_value(&ast->children[2]->content, &index, scopes);
         }
-        struct Value result = execute(function, defined, scopes, max_depth - 1);
+        struct Value result = execute(function, defined, scopes, function_names, max_depth - 1);
         array.data.array->values[i] = value_copy_heap(&result);
     }
     return array;

--- a/src/execution_functions/map_array.h
+++ b/src/execution_functions/map_array.h
@@ -3,6 +3,6 @@
 
 #include "../structures/structures.h"
 
-struct Value map_array(struct Tree * ast, hash_table *defined, struct Scopes * scopes, int max_depth);
+struct Value map_array(struct Tree * ast, hash_table *defined, struct Scopes * scopes, struct Value_array * function_names, int max_depth);
 
 #endif

--- a/src/execution_functions/parallel_execution.c
+++ b/src/execution_functions/parallel_execution.c
@@ -10,11 +10,11 @@ void * parallel_routine(void * bundle_ptr){
     if (bundle->max_depth <= 0) {
         ERROR("Max depth exceeded in computation");
     }
-    execute(bundle->ast, bundle->defined, bundle->scopes, bundle->max_depth - 1);
+    execute(bundle->ast, bundle->defined, bundle->scopes, bundle->function_names, bundle->max_depth - 1);
     return 0;
 }
 
-void parallel_execution(struct Tree * ast, hash_table *defined, struct Scopes * scopes, int max_depth){
+void parallel_execution(struct Tree * ast, hash_table *defined, struct Scopes * scopes, struct Value_array * function_names, int max_depth){
     int num_children = ast->size;
     pthread_t *tid = ARR_MALLOC(num_children, pthread_t);
     struct Execution_bundle * bundle = ARR_MALLOC(num_children, struct Execution_bundle);
@@ -22,6 +22,7 @@ void parallel_execution(struct Tree * ast, hash_table *defined, struct Scopes * 
         bundle[i].ast=ast->children[i];
         bundle[i].defined=defined; // BUG: defined is NOT threadsafe. Needs to be copied.
         bundle[i].scopes=scopes; // BUG: scopes is NOT threadsafe. Needs to be copied.
+        bundle[i].function_names=function_names;
         bundle[i].max_depth = max_depth - 1;
         pthread_create(&tid[i], NULL, &parallel_routine, &bundle[i]);
     }

--- a/src/execution_functions/parallel_execution.h
+++ b/src/execution_functions/parallel_execution.h
@@ -3,6 +3,6 @@
 
 #include "../structures/structures.h"
 
-void parallel_execution(struct Tree * ast, hash_table *defined, struct Scopes * scopes, int max_depth);
+void parallel_execution(struct Tree * ast, hash_table *defined, struct Scopes * scopes, struct Value_array * function_names, int max_depth);
 
 #endif

--- a/src/execution_functions/reduce.c
+++ b/src/execution_functions/reduce.c
@@ -5,7 +5,7 @@
 #include "../core_functions.h"
 #include "../config.h"
 
-struct Value reduce_array(struct Tree * ast, hash_table *defined, struct Scopes * scopes, int max_depth){
+struct Value reduce_array(struct Tree * ast, hash_table *defined, struct Scopes * scopes, struct Value_array * function_names, int max_depth){
     if (max_depth <= 0) {
         ERROR("Max depth exceeded in computation");
     }
@@ -20,7 +20,7 @@ struct Value reduce_array(struct Tree * ast, hash_table *defined, struct Scopes 
     }
     int start = 0;
     struct Value result;
-    struct Value array = execute(ast->children[0], defined, scopes, max_depth - 1);
+    struct Value array = execute(ast->children[0], defined, scopes, function_names, max_depth - 1);
     if (array.type != ARRAY) {
         ERROR("Invalid type for reduce_array: '%c' != ARRAY\n", array.type);
     }
@@ -28,7 +28,7 @@ struct Value reduce_array(struct Tree * ast, hash_table *defined, struct Scopes 
         return value_copy_stack(&array);
     }
     if(ast->size == 5){
-        result = execute(ast->children[4], defined, scopes, max_depth - 1);
+        result = execute(ast->children[4], defined, scopes, function_names, max_depth - 1);
     } else {
         result = *array.data.array->values[0];
         start = 1;
@@ -38,7 +38,7 @@ struct Value reduce_array(struct Tree * ast, hash_table *defined, struct Scopes 
         struct Tree * function = duplicate_tree(ast->children[3]);
         store_let_value(&ast->children[1]->content, &result, scopes);
         store_let_value(&ast->children[2]->content, item, scopes);
-        result = execute(function, defined, scopes, max_depth - 1);
+        result = execute(function, defined, scopes, function_names, max_depth - 1);
     }
     return result;
 }

--- a/src/execution_functions/reduce.h
+++ b/src/execution_functions/reduce.h
@@ -3,6 +3,6 @@
 
 #include "../structures/structures.h"
 
-struct Value reduce_array(struct Tree * ast, hash_table *defined, struct Scopes * scopes, int max_depth);
+struct Value reduce_array(struct Tree * ast, hash_table *defined, struct Scopes * scopes, struct Value_array * function_names, int max_depth);
 
 #endif

--- a/src/execution_functions/reduce_ast.c
+++ b/src/execution_functions/reduce_ast.c
@@ -3,18 +3,18 @@
 #include "../base_util.h"
 #include "../config.h"
 
-struct Value reduce_ast(struct Tree * ast, hash_table *defined, struct Scopes * scopes, int max_depth){
+struct Value reduce_ast(struct Tree * ast, hash_table *defined, struct Scopes * scopes, struct Value_array * function_names, int max_depth){
     if (max_depth <= 0) {
         ERROR("Max depth exceeded in computation");
     }
     if (ast->size < 1) {
         ERROR("Not enough arguments for reduce_ast: %i < 2\n", ast->size);
     }
-    struct Value result = execute(ast->children[0], defined, scopes, max_depth - 1);
+    struct Value result = execute(ast->children[0], defined, scopes, function_names, max_depth - 1);
 
     for(int i = 1; i < ast->size; i++){
         if(ast->children[i]->type == 'f'){
-            struct Value newResult = execute(ast->children[i], defined, scopes, max_depth - 1);
+            struct Value newResult = execute(ast->children[i], defined, scopes, function_names, max_depth - 1);
             result = apply_core_function(ast, result, newResult);
         } else {
             result = apply_core_function(ast, result, ast->children[i]->content);

--- a/src/execution_functions/reduce_ast.h
+++ b/src/execution_functions/reduce_ast.h
@@ -3,6 +3,6 @@
 
 #include "../structures/structures.h"
 
-struct Value reduce_ast(struct Tree * ast, hash_table *defined, struct Scopes * scopes, int max_depth);
+struct Value reduce_ast(struct Tree * ast, hash_table *defined, struct Scopes * scopes, struct Value_array * function_names, int max_depth);
 
 #endif

--- a/src/execution_functions/switch.c
+++ b/src/execution_functions/switch.c
@@ -5,23 +5,23 @@
 #include "../core_functions.h"
 #include "../config.h"
 
-struct Value switch_case(struct Tree * ast, hash_table *defined, struct Scopes * scopes, int max_depth){
+struct Value switch_case(struct Tree * ast, hash_table *defined, struct Scopes * scopes, struct Value_array * function_names, int max_depth){
     if (max_depth <= 0) {
         ERROR("Max depth exceeded in computation");
     }
     for(int i = 1; i < ast->size; i++){
         struct Tree * routine = ast->children[i];
         if(routine->type == 'k' && string_matches_heap(&default_const, &routine->content.data.str)){
-            return execute(routine->children[0], defined, scopes, max_depth - 1);
+            return execute(routine->children[0], defined, scopes, function_names, max_depth - 1);
         }
         if (routine->size != 2) {
             ERROR("Invalid syntax for switch_case: %i != 2", routine->size);
         }
         routine->children[1] = ast->children[0];
-        struct Value result = execute(routine, defined, scopes, max_depth - 1);
+        struct Value result = execute(routine, defined, scopes, function_names, max_depth - 1);
         if(value_as_bool(&result)){
             struct Tree * return_value = routine->children[1];
-            return execute(return_value, defined, scopes, max_depth - 1);
+            return execute(return_value, defined, scopes, function_names, max_depth - 1);
         }
     }
     struct Value result;

--- a/src/execution_functions/switch.h
+++ b/src/execution_functions/switch.h
@@ -3,6 +3,6 @@
 
 #include "../structures/structures.h"
 
-struct Value switch_case(struct Tree * ast, hash_table *defined, struct Scopes * scopes, int max_depth);
+struct Value switch_case(struct Tree * ast, hash_table *defined, struct Scopes * scopes, struct Value_array * function_names, int max_depth);
 
 #endif

--- a/src/execution_functions/while_loop.c
+++ b/src/execution_functions/while_loop.c
@@ -4,14 +4,14 @@
 #include "../base_util.h"
 #include "../config.h"
 
-void while_loop(struct Tree * ast, hash_table *defined, struct Scopes * scopes, int max_depth){
+void while_loop(struct Tree * ast, hash_table *defined, struct Scopes * scopes, struct Value_array * function_names, int max_depth){
     if(ast->size != 2){
         ERROR("Not enough arguments for while: %i < 2\n", ast->size);
     }
     for(int i = 0; LOOP_MAX == -1 || i < LOOP_MAX; (LOOP_MAX == -1) ? i : i++){
-        struct Value condition = execute(ast->children[0], defined, scopes, max_depth - 1);
+        struct Value condition = execute(ast->children[0], defined, scopes, function_names, max_depth - 1);
         if(value_as_bool(&condition)){
-            execute(ast->children[1], defined, scopes, max_depth - 1);
+            execute(ast->children[1], defined, scopes, function_names, max_depth - 1);
         } else {
             break;
         }

--- a/src/execution_functions/while_loop.h
+++ b/src/execution_functions/while_loop.h
@@ -3,6 +3,6 @@
 
 #include "../structures/structures.h"
 
-void while_loop(struct Tree * ast, hash_table *defined, struct Scopes * scopes, int max_depth);
+void while_loop(struct Tree * ast, hash_table *defined, struct Scopes * scopes, struct Value_array * function_names, int max_depth);
 
 #endif

--- a/src/huo.c
+++ b/src/huo.c
@@ -11,11 +11,13 @@
 #include "parser.h"
 #include "structures/structures.h"
 #include "execution_functions/read_file.h"
+#include "build_array.h"
 #include "execute.h"
 #include "store_defs.h"
 #include "base_util.h"
 #include "huo.h"
 #include "config.h"
+#include "core_functions.h"
 
 #if defined(_POSIX_VERSION) || defined(__linux__) || defined(__APPLE__)
 
@@ -170,6 +172,14 @@ int main(int argc, char const *argv[]) {
 "-h, --help print this help message and exit\n");
         return error_flag ? 1 : 0; // Redundant for now, but reminder to maybe return a different error code later
     }
+    struct Tokens fn_tokens = {
+        .tokens = NULL,
+        .length = 0,
+        .counter = 0
+    };
+
+    tokenize(function_names, &fn_tokens);
+    struct Value_array * function_names = build_array(&fn_tokens);
 
     struct Tokens t = {
         .tokens = NULL,
@@ -178,9 +188,9 @@ int main(int argc, char const *argv[]) {
     };
 
     struct Tokens * tokens = tokenize(to_execute, &t);
-    //for(int i = 0; i < tokens->length; i++){
+    // for(int i = 0; i < tokens->length; i++){
     //     printf("%c", tokens->tokens[i].type);
-    //}
+    // }
 
     struct Tree root;
     root.type = 'r';
@@ -202,7 +212,7 @@ int main(int argc, char const *argv[]) {
 
     int num_defs = store_defs(&root, defined);
     for(int i = num_defs; i < root.size; i++){
-        execute(root.children[i], defined, scopes, RECURSE_MAX);
+        execute(root.children[i], defined, scopes, function_names, RECURSE_MAX);
     }
     return 0;
 }

--- a/src/process_defs.c
+++ b/src/process_defs.c
@@ -9,7 +9,7 @@
 #include "structures/hash_table.h"
 #include "config.h"
 
-void make_args_map(struct Tree * ast, hash_table *defined, struct Scopes * scopes, struct Tree *function, int max_depth) {
+void make_args_map(struct Tree * ast, hash_table *defined, struct Scopes * scopes, struct Value_array * function_names, struct Tree *function, int max_depth) {
     // we want to evaluate the values passed into the function
     // but store the result in the next scope, not the current one
     if (function->size - 2 != ast->size) {
@@ -17,7 +17,7 @@ void make_args_map(struct Tree * ast, hash_table *defined, struct Scopes * scope
     }
     struct Value vals[ast->size];
     for(int i = 0; i < ast->size; i++){
-        vals[i] = execute(ast->children[i], defined, scopes, max_depth - 1);
+        vals[i] = execute(ast->children[i], defined, scopes, function_names, max_depth - 1);
     }
     make_scope(scopes);
     for(int l = 0; l < ast->size; l++){

--- a/src/process_defs.h
+++ b/src/process_defs.h
@@ -3,7 +3,7 @@
 
 #include "structures/structures.h"
 
-void make_args_map(struct Tree * ast, hash_table * defined, struct Scopes * scopes, struct Tree *function, int max_depth);
+void make_args_map(struct Tree * ast, hash_table * defined, struct Scopes * scopes, struct Value_array * function_names, struct Tree *function, int max_depth);
 struct Tree *get_defined_body(struct Tree * function);
 struct Tree *get_defined_func(hash_table *defined, struct String key);
 

--- a/src/structures/array.c
+++ b/src/structures/array.c
@@ -62,3 +62,22 @@ bool array_matches(struct Value_array *base, struct Value_array *compare){
     }
     return true;
 }
+
+bool array_contains(struct Value *item, struct Value_array *array){
+    enum Value_type t = item->type;
+    for(int i = 0; i < array->size; i++){
+        if(array->values[i]->type == t){
+            if(array->values[i]->type == KEYWORD && t == KEYWORD){
+                if(string_matches_heap(&array->values[i]->data.str, &item->data.str)){
+                    return true;
+                }
+            }
+            else if (t == FLOAT){
+                if(array->values[i]->data.fl == item->data.fl){
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+}

--- a/src/structures/array.h
+++ b/src/structures/array.h
@@ -14,5 +14,6 @@ struct Value_array *array_copy_heap(struct Value_array *arr);
 struct Value_array *array_concat_heap(struct Value_array *a, struct Value_array *b);
 void array_concat_to(struct Value_array *to, struct Value_array *from);
 bool array_matches(struct Value_array *base, struct Value_array *compare);
+bool array_contains(struct Value *item, struct Value_array *array);
 
 #endif

--- a/src/structures/structures.h
+++ b/src/structures/structures.h
@@ -35,6 +35,7 @@ struct Execution_bundle {
     struct Tree * ast;
     hash_table *defined;
     struct Scopes * scopes;
+    struct Value_array * function_names;
     int max_depth;
 };
 


### PR DESCRIPTION
OK @TheLoneWolfling this one took a while. I tried a few different approaches to clean up execute but none of them were clean. I finally settled on the function_names array you see below because it allows us to definitively separate native functions that manipulate the AST from core functions that just consume two values. We can also use the contains function I added (it's in pretty poor shape now but I'll fix it up) to create another native function for arrays and strings. Now that this is done I should be able to help you more with all the structures and whatnot.

I thought about a few different ways to make the execute function more abstract but I didn't find anything I liked at this point. I like how there are so few abstractions that it's really easy to see what's going on. At the very least execute.c is much smaller now and easy to deal with so we can improve other parts of the language without worrying too much about it.
